### PR TITLE
Convert to use Yampa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cabal-dev
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
+playing-with-balls.cabal
 *.prof
 *.aux
 *.hp

--- a/package.yaml
+++ b/package.yaml
@@ -14,11 +14,11 @@ extra-source-files:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         A simple simulation to learn FRP with Netwire
+description:         A simple simulation to learn FRP with Yampa
 
 dependencies:
 - base >= 4.7 && < 5
-- netwire >= 5
+- Yampa >= 0.14
 - gloss >= 1.13
 - lens >= 5.2
 - transformers >= 0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,5 @@ packages:
 - .
 extra-deps:
 - lens-5.2.3
+- Yampa-0.14.5
 resolver: lts-18.28


### PR DESCRIPTION
As Netwire was [deprecated](https://www.reddit.com/r/haskell/comments/7yezo2/til_netwire_frp_library_is_basically_deprecated/) some time ago, I'm moving over to Yampa.  It's an OK interface (sadly and mystifyingly requiring the use of an `IORef` to pass state out of the signal??), but it does work, and I was able to trim down the orbit mechanic into a much simpler form.  I'd be open to shifting to reactive banana if it's better, but this works for now.